### PR TITLE
体重の折れ線グラフが日付通りにグラフが表示されるようにした

### DIFF
--- a/frontend/src/components/Weight/WeightChart.jsx
+++ b/frontend/src/components/Weight/WeightChart.jsx
@@ -42,6 +42,9 @@ const WeightChart = () => {
         console.log("Fetched weights data:", weights); // デバッグ用
 
         if (weights && weights.length > 0) {
+          // 日付でソート
+          weights.sort((a, b) => new Date(a.date) - new Date(b.date));
+
           let filteredWeights;
           const now = new Date();
 


### PR DESCRIPTION
frontend/src/components/Weight/WeightChart.jsxファイルを編集して
・体重の折れ線グラフが日付通りにグラフが表示されるようにした

<img width="884" alt="スクリーンショット 2025-02-14 10 04 31" src="https://github.com/user-attachments/assets/7339ce92-aa4d-45f1-b16e-6a46bfc2d5c7" />
