### PR TITLE
フッターに体重とカロリーとホームと成果と投稿一覧に遷移するボタンを配置

### DIFF
--- a/frontend/src/components/Home/Footer/Footer.css
+++ b/frontend/src/components/Home/Footer/Footer.css
@@ -1,45 +1,40 @@
 .footer {
     background-color: #5D9CEC;
-    color: white; /* テキストの色を白に設定 */
-    text-align: center; /* テキストを中央揃え */
-    padding: 8px 0; /* 上下に20px */
-    position: fixed; /* 固定位置に設定 */
-    bottom: 0; /* 下端に固定 */
-    width: 100%; /* 幅を100%に設定 */
-    left: 50%; /* 左端を50%に設定 */
-    transform: translateX(-50%); /* 中央に固定するためにX軸方向に50%移動 */
+    color: white;
+    text-align: center;
+    padding: 8px 0;
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 1000; 
 }
 
 .footer-content {
-    display: flex; /* フレックスボックスを使用 */
-    justify-content: center; /* 子要素を中央揃え */
-    align-items: center; /* 子要素を垂直方向に中央揃え */
-    gap: 20px; /* 子要素間の間隔を設定 */
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    width: 100%;
 }
 
-.link {
-    color: white; /* テキストの色を白に設定 */
-    text-decoration: none; /* 下線を消す */
-    font-weight: bold; /* 文字を太くする */
-    font-size: 16px; /* フォントサイズを設定 */
-    transition: color 0.3s ease; /* 色の変化をスムーズに */
+.footer-nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: white;
+    text-decoration: none;
+    font-size: 14px;
+    padding: 5px 0;
+    transition: color 0.3s ease;
+    width: 20%;
 }
 
-.link:hover {
-    color: #FFD700; /* ホバー時の色をゴールドに設定 */
+.footer-nav-item:hover {
+    color: #FFD700;
 }
 
-.iconLink {
-    color: white; /* アイコンの色を白に設定 */
-    font-size: 24px; /* アイコンのサイズを設定 */
-    transition: color 0.3s ease; /* 色の変化をスムーズに */
-}
-
-.iconLink:hover {
-    color: #FFD700; /* ホバー時の色をゴールドに設定 */
-}
-
-.copy {
-    font-size: 14px; /* フォントサイズを設定 */
+.footer-icon {
+    font-size: 20px;
+    margin-bottom: 4px;
 }

--- a/frontend/src/components/Home/Footer/Footer.jsx
+++ b/frontend/src/components/Home/Footer/Footer.jsx
@@ -1,33 +1,48 @@
 // このコードは、ウェブサイトのフッターを表示するためのコンポーネントです。
-// フッターには、リンクとソーシャルメディアのアイコンが含まれています。
+// フッターには、ホーム画面、体重、カロリー関係、成果、みんなの投稿のリンクが含まれています。
 
-import React from 'react'; // Reactをインポート
-import { Link } from 'react-router-dom'; // React RouterのLinkコンポーネントをインポート
-import { FaSquareXTwitter, FaGithub } from 'react-icons/fa6'; // react-iconsからFaSquareXTwitterとFaGithubをインポート
-import './Footer.css'; // CSSファイルをインポート
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { FaHome, FaWeight, FaFire, FaTrophy, FaUsers } from 'react-icons/fa';
+import './Footer.css';
 
 // Footerコンポーネントを定義
 function Footer() {
   return (
     <footer className="footer">
       <div className="footer-content">
-        {/* お問い合わせ、利用規約、プライバシーポリシーのリンクを表示 */}
-        <Link to="/contact" className="link">お問い合わせ</Link>
-        <Link to="/terms" className="link">利用規約</Link>
-        <Link to="/privacy" className="link">プライバシーポリシー</Link>
-        {/* XとGitHubのアイコンを表示 */}
-        <a href="https://x.com/michihiro721" className="iconLink" target="_blank" rel="noopener noreferrer">
-          <FaSquareXTwitter className="icon" />
-        </a>
-        <a href="https://github.com/michihiro721/" className="iconLink" target="_blank" rel="noopener noreferrer">
-          <FaGithub className="icon" />
-        </a>
-        {/* コピーライト情報を表示 */}
-        <span className="copy">© 2025 - ver.1.00</span>
+        {/* 体重のリンク */}
+        <Link to="/weight" className="footer-nav-item">
+          <FaWeight className="footer-icon" />
+          <span>体重</span>
+        </Link>
+        
+        {/* カロリー関係のリンク */}
+        <Link to="/calorie-info" className="footer-nav-item">
+          <FaFire className="footer-icon" />
+          <span>カロリー</span>
+        </Link>
+        
+        {/* ホーム画面のリンク */}
+        <Link to="/" className="footer-nav-item">
+          <FaHome className="footer-icon" />
+          <span>ホーム</span>
+        </Link>
+        
+        {/* 成果のリンク */}
+        <Link to="/achievements" className="footer-nav-item">
+          <FaTrophy className="footer-icon" />
+          <span>成果</span>
+        </Link>
+        
+        {/* みんなの投稿一覧のリンク */}
+        <Link to="/posts" className="footer-nav-item">
+          <FaUsers className="footer-icon" />
+          <span>投稿一覧</span>
+        </Link>
       </div>
     </footer>
   );
 }
 
-// Footerコンポーネントをエクスポート
 export default Footer;


### PR DESCRIPTION
スマホで使いやすくするために、「ホーム画面」「体重」「カロリー関係」「成果」「みんなの投稿」をフッターに表示させた。
<img width="1439" alt="スクリーンショット 2025-03-15 18 15 53" src="https://github.com/user-attachments/assets/86bcb83a-1492-48e3-b135-1e501de9d78a" />
