### PR TITLE
スマホ画面だとヘッダーのバックボタンを非表示にした

### DIFF
--- a/frontend/src/components/Home/Header/styles/header.css
+++ b/frontend/src/components/Home/Header/styles/header.css
@@ -67,10 +67,9 @@
     font-size: 24px;
   }
 
+  /* スマホ表示ではバックボタンを非表示 */
   .header-back-button {
-    font-size: 30px;
-    margin-left: 10px;
-    top: 15px;
+    display: none !important; /* !importantで優先度を上げる */
   }
 }
 
@@ -83,10 +82,5 @@
 
   .header-title {
     font-size: 20px;
-  }
-  
-  .header-back-button {
-    font-size: 26px;
-    margin-left: 5px;
   }
 }


### PR DESCRIPTION
スマホ画面だとヘッダーのバックボタンを非表示にした

PC画面
<img width="1422" alt="スクリーンショット 2025-04-02 2 48 57" src="https://github.com/user-attachments/assets/a34407a6-0e2b-44fb-963c-f743fd44e7d4" />

スマホ画面
<img width="283" alt="スクリーンショット 2025-04-02 2 49 08" src="https://github.com/user-attachments/assets/c1578ebd-bf5e-43a0-b6f8-17c89ce1210d" />
