### PR TITLE
ESLintの設定を修正してprocess.env参照のエラーを解消

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -5,7 +5,15 @@ import reactHooksPlugin from "eslint-plugin-react-hooks";
 
 export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
-  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: globals.browser } },
+  { 
+    files: ["**/*.{js,mjs,cjs,jsx}"], 
+    languageOptions: { 
+      globals: {
+        ...globals.browser,
+        ...globals.node  // Node.jsのグローバル変数を追加（processを含む）
+      } 
+    }
+  },
   js.configs.recommended,
   pluginReact.configs.flat.recommended,
   {


### PR DESCRIPTION
ESLintの設定を修正してprocess.env参照のエラーを解消
frontend/eslint.config.mjsに「...globals.node 」を追加