### PR TITLE
Calender.jsxのリファクタリング

### DIFF
--- a/frontend/src/components/Home/Body/Calender/Calender.jsx
+++ b/frontend/src/components/Home/Body/Calender/Calender.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import Calendar from 'react-calendar';
+import React from 'react';
 import 'react-calendar/dist/Calendar.css';
 import './styles/Calendar.css';
+import PropTypes from 'prop-types';
 
 // カレンダーの曜日の表示をカスタマイズするための関数
 export const CalenderFormatShortWeekday = (locale, date) => {
@@ -30,18 +30,21 @@ export const CalenderTileContent = ({ date, view }) => {
   return null;
 };
 
-function Calender({ onDateSelect }) {
-  const [date, setDate] = useState(new Date());
-
-  const onChange = (newDate) => {
-    setDate(newDate);
-    if (onDateSelect) {
-      onDateSelect(newDate);
-    }
-  };
-
+function Calender() {
   // カレンダーを非表示にするためにnullを返す
   return null;
 }
+
+CalenderTileClassName.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  view: PropTypes.string.isRequired
+};
+
+CalenderTileContent.propTypes = {
+  date: PropTypes.instanceOf(Date).isRequired,
+  view: PropTypes.string.isRequired
+};
+
+Calender.propTypes = {};
 
 export default Calender;


### PR DESCRIPTION
・不要なインポートの削除
Calendar コンポーネントのインポート
useState のインポート

・未使用の変数とロジックの削除
date と setDate の状態管理
onChange 関数

PropTypes をインポートして追加

コンポーネントの簡素化
Calender コンポーネントから引数 { onDateSelect } を削除
Calender.propTypes を空オブジェクトに変更
