### PR TITLE
トレーニングのkgの入力フォームをクリックした際に表示される電卓風のモーダルウィンドウを開いた際に、0がデフォルトで表示されてしまっていた…

### DIFF
--- a/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/TrainingRecord.jsx
+++ b/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/TrainingRecord.jsx
@@ -327,7 +327,7 @@ const TrainingRecord = () => {
   const openModal = (trainingIndex, setIndex, field, value) => {
     setCurrentSet({ trainingIndex, setIndex });
     setCurrentField(field);
-    setCurrentValue(value);
+    setCurrentValue(value === 0 ? "" : value);
     setModalVisible(true);
   };
 


### PR DESCRIPTION
トレーニングのkgの入力フォームをクリックした際に表示される電卓風のモーダルウィンドウを開いた際に、0がデフォルトで表示されてしまっていたので、0が表示されないように修正した