### PR TITLE
24時間の有効期限をフロントとバックでどちらも定義していたので、バックの記載を削除

### DIFF
--- a/backend/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/backend/app/controllers/users/omniauth_callbacks_controller.rb
@@ -38,7 +38,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def generate_jwt_token(user)
     payload = {
       sub: user.id,
-      exp: (Time.now + 24.hours).to_i,
       email: user.email,
       jti: SecureRandom.uuid
     }


### PR DESCRIPTION
24時間の有効期限をフロントとバックでどちらも定義していたので、バックの記載を削除