### PR TITLE
コピーモーダルスタイル修正

### DIFF
--- a/frontend/src/components/Posts/styles/TrainingCopyModal.css
+++ b/frontend/src/components/Posts/styles/TrainingCopyModal.css
@@ -20,6 +20,9 @@
     max-height: 80vh;
     overflow-y: auto;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    position: relative;
+    top: 0;
+    margin: auto;
   }
   
   .training-copy-modal-title {
@@ -66,6 +69,7 @@
     display: flex;
     justify-content: space-between;
     margin-top: 20px;
+    gap: 10px;
   }
   
   .training-copy-modal-cancel-button,
@@ -76,6 +80,7 @@
     font-weight: bold;
     cursor: pointer;
     transition: background-color 0.3s;
+    flex: 1;
   }
   
   .training-copy-modal-cancel-button {
@@ -144,16 +149,18 @@
     .training-copy-modal {
       width: 95%;
       padding: 15px;
+      top: -30px;
     }
     
     .training-copy-modal-buttons {
-      flex-direction: column;
+      flex-direction: row;
       gap: 10px;
     }
     
     .training-copy-modal-cancel-button,
     .training-copy-modal-save-button {
-      width: 100%;
+      width: auto;
+      flex: 1;
     }
   }
   
@@ -172,11 +179,13 @@
     
     .training-copy-modal-buttons {
       margin-top: 10px;
+      flex-direction: row;
     }
     
     .training-copy-modal-cancel-button,
     .training-copy-modal-save-button {
       padding: 8px 15px;
       font-size: 0.9rem;
+      flex: 1;
     }
   }


### PR DESCRIPTION
コピーモーダルスタイル修正
保存ボタンがスマホ画面だと見切れていたので修正した

<img width="387" alt="スクリーンショット 2025-04-21 15 18 45" src="https://github.com/user-attachments/assets/34d54684-2958-4c91-b3c3-71a748dab651" />
