### PR TITLE
アプリの使い方説明画面への遷移ウィンドウの文言を変更

### DIFF
--- a/frontend/src/components/Home/Footer/Footer.jsx
+++ b/frontend/src/components/Home/Footer/Footer.jsx
@@ -55,7 +55,7 @@ function Footer() {
             <h2>「ダイエットメーカー」をご利用頂き<br />ありがとうございます！</h2>
             <h3>アプリの使い方を確認しますか？</h3>
             <p className="welcome-description">
-              簡単な使い方ガイドを見て、<br />アプリの機能を最大限に活用しましょう✨
+              新規ユーザーの方 ➡️「確認する」<br />既にご利用中の方 ➡️「ログインする」
             </p>
             <div className="welcome-modal-buttons">
               <button


### PR DESCRIPTION
アプリの使い方説明画面への遷移ウィンドウの文言を変更


<img width="1440" alt="スクリーンショット 2025-05-27 2 29 52" src="https://github.com/user-attachments/assets/7529f814-70a0-4270-b036-ba4246ee7349" />
