### PR TITLE
提案された種目の横にアイコンを設置して、そこから種目のやり方のサイトに飛ぶ機能を追加

### DIFF
--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen1.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen1.jsx
@@ -25,20 +25,26 @@ export const getTrainingMenu1 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
@@ -46,7 +52,71 @@ export const getTrainingMenu1 = (gender, gymType, frequency, volume) => {
     });
   };
 
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ベンチプレス": {
+        url: ""
+      },
+      "インクラインダンベルフライ": {
+        url: ""
+      },
+      "ペックフライ": {
+        url: ""
+      },
+      "デットリフト": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "ラットプルダウン": {
+        url: ""
+      },
+      "バーベルスクワット": {
+        url: ""
+      },
+      "レッグプレス": {
+        url: ""
+      },
+      "レッグカール": {
+        url: ""
+      },
+      "ミリタリープレス": {
+        url: ""
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "バーベルカール": {
+        url: ""
+      },
+      "インクラインダンベルカール": {
+        url: ""
+      },
+      "ケーブルプルオーバー": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
 
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
+  };
 
   // **条件ごとに適切なメニューを決定**
   if (gender === "男性") {

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen2.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen2.jsx
@@ -25,25 +25,97 @@ export const getTrainingMenu2 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ベンチプレス": {
+        url: ""
+      },
+      "インクラインダンベルプレス": {
+        url: ""
+      },
+      "ダンベルフライ": {
+        url: ""
+      },
+      "デットリフト": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "懸垂": {
+        url: ""
+      },
+      "バーベルスクワット": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: ""
+      },
+      "ミリタリープレス": {
+        url: ""
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "バーベルカール": {
+        url: ""
+      },
+      "インクラインダンベルカール": {
+        url: ""
+      },
+      "ディップス": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen3.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen3.jsx
@@ -25,25 +25,100 @@ export const getTrainingMenu3 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "インクラインダンベルプレス": {
+        url: ""
+      },
+      "ダンベルフライ": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: ""
+      },
+      "ダンベルデットリフト": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "ダンベルリアデルトフライ": {
+        url: ""
+      },
+      "ダンベルスクワット": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: ""
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "アーノルドプレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "ハンマーカール": {
+        url: ""
+      },
+      "インクラインダンベルカール": {
+        url: ""
+      },
+      "ディップス": {
+        url: ""
+      },
+      "ダンベルカール": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen4.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen4.jsx
@@ -25,25 +25,67 @@ export const getTrainingMenu4 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ディップス": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: ""
+      },
+      "懸垂": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen5.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen5.jsx
@@ -25,25 +25,97 @@ export const getTrainingMenu5 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "インクラインダンベルプレス": {
+        url: ""
+      },
+      "ダンベルフライ": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: ""
+      },
+      "懸垂": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "ダンベルリアデルトフライ": {
+        url: ""
+      },
+      "ダンベルスクワット": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: ""
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "アーノルドプレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "ハンマーカール": {
+        url: ""
+      },
+      "インクラインダンベルカール": {
+        url: ""
+      },
+      "ディップス": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuMen6.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuMen6.jsx
@@ -25,25 +25,64 @@ export const getTrainingMenu6 = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ディップス（椅子）": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: ""
+      },
+      "クランチ": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman1.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman1.jsx
@@ -25,25 +25,85 @@ export const getTrainingMenu1Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "レッグプレス": {
+        url: ""
+      },
+      "アブダクション": {
+        url: ""
+      },
+      "ラットプルダウン": {
+        url: ""
+      },
+      "シーテッドロー": {
+        url: ""
+      },
+      "バーベルスクワット": {
+        url: ""
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "レッグカール": {
+        url: ""
+      },
+      "キックバック": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "トレッドミル": {
+        url: ""
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman2.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman2.jsx
@@ -25,25 +25,88 @@ export const getTrainingMenu2Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "ダンベルスクワット": {
+        url: ""
+      },
+      "キックバック": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "バーベルスクワット": {
+        url: ""
+      },
+      "スクワット": {
+        url: "https://www.shopjapan.co.jp/diet_labo/legs/article_018/"
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "レッグレイズ": {
+        url: ""
+      },
+      "ショルダープレス": {
+        url: ""
+      },
+      "ウォーキング": {
+        url: "https://halmek.co.jp/beauty/c/healthr/2987"
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman3.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman3.jsx
@@ -25,25 +25,88 @@ export const getTrainingMenu3Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "ダンベルスクワット": {
+        url: ""
+      },
+      "キックバック": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "スクワット": {
+        url: "https://www.shopjapan.co.jp/diet_labo/legs/article_018/"
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "腕立て伏せ": {
+        url: "https://nakayamakinnikun.com/blogs/blog/weighttraining-push-up?srsltid=AfmBOoqRZn__h_WqYU81J5wCgYWElmeg4cUDB6l43sqheeWuR4dUDI80"
+      },
+      "デットリフト": {
+        url: ""
+      },
+      "バーベルロー": {
+        url: ""
+      },
+      "ウォーキング": {
+        url: "https://halmek.co.jp/beauty/c/healthr/2987"
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**
@@ -57,7 +120,7 @@ export const getTrainingMenu3Woman = (gender, gymType, frequency, volume) => {
             { day: "水曜日", exercises: [{ name: "ダンベルスクワット", reps: 10, sets: 5, workout_id: 51 }, { name: "ブルガリアンスクワット", reps: 12, sets: 5, workout_id: 56 }, { name: "スクワット", reps: 15, sets: 5, workout_id: 51 }] },
             { day: "木曜日", exercises: [{ name: "ダンベルショルダープレス", reps: 15, sets: 5, workout_id: 35 }, { name: "サイドレイズ", reps: 15, sets: 5, workout_id: 31 }] },
             { day: "金曜日", exercises: [{ name: "クランチ", reps: 20, sets: 5, workout_id: 60 }, { name: "ロシアンツイスト", reps: 20, sets: 5, workout_id: 63 }] },
-            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 5, workout_id: 58 }, { name: "腕立て", reps: 10, sets: 5, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
+            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 5, workout_id: 58 }, { name: "腕立て伏せ", reps: 10, sets: 5, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
             ]);
             } else if (volume === "普通がいいかな〜") {
             createMenu("6回/週の標準メニュー", [
@@ -66,7 +129,7 @@ export const getTrainingMenu3Woman = (gender, gymType, frequency, volume) => {
             { day: "水曜日", exercises: [{ name: "ダンベルスクワット", reps: 10, sets: 3, workout_id: 51 }, { name: "ブルガリアンスクワット", reps: 12, sets: 3, workout_id: 56 }, { name: "スクワット", reps: 15, sets: 3, workout_id: 51 }] },
             { day: "木曜日", exercises: [{ name: "ダンベルショルダープレス", reps: 15, sets: 3, workout_id: 35 }, { name: "サイドレイズ", reps: 15, sets: 3, workout_id: 31 }] },
             { day: "金曜日", exercises: [{ name: "クランチ", reps: 20, sets: 3, workout_id: 60 }, { name: "ロシアンツイスト", reps: 20, sets: 3, workout_id: 63 }] },
-            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 3, workout_id: 58 }, { name: "腕立て", reps: 10, sets: 3, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
+            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 3, workout_id: 58 }, { name: "腕立て伏せ", reps: 10, sets: 3, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
             ]);
             } else {
             createMenu("6回/週の軽めメニュー", [
@@ -75,7 +138,7 @@ export const getTrainingMenu3Woman = (gender, gymType, frequency, volume) => {
             { day: "水曜日", exercises: [{ name: "ダンベルスクワット", reps: 10, sets: 2, workout_id: 51 }, { name: "ブルガリアンスクワット", reps: 12, sets: 2, workout_id: 56 }, { name: "スクワット", reps: 15, sets: 2, workout_id: 51 }] },
             { day: "木曜日", exercises: [{ name: "ダンベルショルダープレス", reps: 15, sets: 2, workout_id: 35 }, { name: "サイドレイズ", reps: 15, sets: 2, workout_id: 31 }] },
             { day: "金曜日", exercises: [{ name: "クランチ", reps: 20, sets: 2, workout_id: 60 }, { name: "ロシアンツイスト", reps: 20, sets: 2, workout_id: 63 }] },
-            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 2, workout_id: 58 }, { name: "腕立て", reps: 10, sets: 2, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
+            { day: "土曜日", exercises: [{ name: "ヒップスラスト", reps: 12, sets: 2, workout_id: 58 }, { name: "腕立て伏せ", reps: 10, sets: 2, workout_id: 16 }, { name: "ウォーキング", duration: "20分", workout_id: 69 }] },
             ]);
         }
       } else if (frequency === "5回/週") {

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman4.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman4.jsx
@@ -25,25 +25,73 @@ export const getTrainingMenu4Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "スクワット": {
+        url: "https://www.shopjapan.co.jp/diet_labo/legs/article_018/"
+      },
+      "懸垂": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: "https://nakayamakinnikun.com/blogs/blog/weighttraining-push-up?srsltid=AfmBOoqRZn__h_WqYU81J5wCgYWElmeg4cUDB6l43sqheeWuR4dUDI80"
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "ディップス（椅子）": {
+        url: "https://tarzanweb.jp/post-202323"
+      },
+      "ウォーキング": {
+        url: "https://halmek.co.jp/beauty/c/healthr/2987"
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman5.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman5.jsx
@@ -25,25 +25,94 @@ export const getTrainingMenu5Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "スクワット": {
+        url: "https://www.shopjapan.co.jp/diet_labo/legs/article_018/"
+      },
+      "ダンベルスクワット": {
+        url: ""
+      },
+      "キックバック": {
+        url: ""
+      },
+      "ダンベルローイング": {
+        url: ""
+      },
+      "バーベルスクワット": {
+        url: ""
+      },
+      "ダンベルショルダープレス": {
+        url: ""
+      },
+      "サイドレイズ": {
+        url: ""
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "懸垂": {
+        url: ""
+      },
+      "レッグレイズ": {
+        url: ""
+      },
+      "腕立て伏せ": {
+        url: "https://nakayamakinnikun.com/blogs/blog/weighttraining-push-up?srsltid=AfmBOoqRZn__h_WqYU81J5wCgYWElmeg4cUDB6l43sqheeWuR4dUDI80"
+      },
+      "ディップス（椅子）": {
+        url: "https://tarzanweb.jp/post-202323"
+      },
+      "ウォーキング": {
+        url: "https://halmek.co.jp/beauty/c/healthr/2987"
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/GetTrainingMenuWoman6.jsx
+++ b/frontend/src/components/TrainingMenu/GetTrainingMenuWoman6.jsx
@@ -25,25 +25,70 @@ export const getTrainingMenu6Woman = (gender, gymType, frequency, volume) => {
         exercises: item.exercises.map((exercise, exerciseIndex) => {
           // 有酸素運動（durationあり）とそれ以外で処理を分ける
           if (exercise.duration) {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               duration: exercise.duration,
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           } else {
+            const exerciseInfo = getExerciseInfo(exercise.name, exercise.workout_id);
             return {
               key: `${itemIndex}-${exerciseIndex}`,
               name: exercise.name,
               sets: exercise.sets,
               reps: exercise.reps,
               weight: 0, // 重量は0で初期化
-              workout_id: exercise.workout_id
+              workout_id: exercise.workout_id,
+              icon: exerciseInfo.icon,
+              tutorialUrl: exerciseInfo.url
             };
           }
         })
       });
     });
+  };
+
+  // 種目ごとにやり方が載っているサイトのURLを設定
+  const getExerciseInfo = (exerciseName, workoutId) => {
+    const exerciseConfig = {
+      "ヒップスラスト": {
+        url: "https://qool.jp/200401"
+      },
+      "ブルガリアンスクワット": {
+        url: "https://ufit.co.jp/blogs/training/bulgariansquats?srsltid=AfmBOoq6pdkF0l0kgLnCXVVCGXuE6rLe23E0hJZsaNlae0TRRE8IyXUA"
+      },
+      "スクワット": {
+        url: "https://www.shopjapan.co.jp/diet_labo/legs/article_018/"
+      },
+      "ディップス（椅子）": {
+        url: "https://tarzanweb.jp/post-202323"
+      },
+      "腕立て伏せ": {
+        url: "https://nakayamakinnikun.com/blogs/blog/weighttraining-push-up?srsltid=AfmBOoqRZn__h_WqYU81J5wCgYWElmeg4cUDB6l43sqheeWuR4dUDI80"
+      },
+      "クランチ": {
+        url: "https://fitrize.jp/crunch/"
+      },
+      "ロシアンツイスト": {
+        url: "https://kekefit.com/russian-twist/"
+      },
+      "ウォーキング": {
+        url: "https://halmek.co.jp/beauty/c/healthr/2987"
+      }
+    };
+
+    const config = exerciseConfig[exerciseName] || {
+      url: `https://example.com/exercise-tutorial/${workoutId}`
+    };
+
+    return {
+      icon: "FaQuestionCircle",
+      url: config.url
+    };
   };
 
   // **条件ごとに適切なメニューを決定**

--- a/frontend/src/components/TrainingMenu/TrainingMenu.jsx
+++ b/frontend/src/components/TrainingMenu/TrainingMenu.jsx
@@ -16,6 +16,7 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import './styles/TrainingMenu.css';
 import { CalenderFormatShortWeekday, CalenderTileClassName, CalenderTileContent } from "../Home/Body/Calender/Calender";
+import { FaQuestionCircle } from "react-icons/fa";
 
 
 const TrainingMenu = () => {
@@ -81,6 +82,15 @@ const TrainingMenu = () => {
       }
     }
     setMenu(generatedMenu);
+  };
+
+
+  const handleExerciseIconClick = (exercise) => {
+    if (exercise.tutorialUrl) {
+      window.open(exercise.tutorialUrl, '_blank');
+    } else {
+      alert(`${exercise.name}のやり方ページは準備中です。`);
+    }
   };
 
   const handleSaveMenu = async () => {
@@ -226,14 +236,21 @@ const TrainingMenu = () => {
                   <li key={itemIndex} className="training-menu-list-item">
                     <span className="training-menu-day">{item.day}:</span>
                     <ul>
-                    {item.exercises.map((exercise) => (
-                      <li key={exercise.key}>
-                        {exercise.name}
-                        {exercise.duration ?
-                          ` - ${exercise.duration}` :
-                          ` - ${exercise.sets}セット x ${exercise.reps}回`}
-                      </li>
-                    ))}
+                      {item.exercises.map((exercise) => (
+                        <li key={exercise.key} className="training-menu-exercise-item">
+                          <FaQuestionCircle
+                            className="training-menu-exercise-icon"
+                            onClick={() => handleExerciseIconClick(exercise)}
+                            title={`${exercise.name}のやり方を見る`}
+                          />
+                          <span className="training-menu-exercise-details">
+                            {exercise.name}
+                            {exercise.duration ?
+                              ` - ${exercise.duration}` :
+                              ` - ${exercise.sets}セット x ${exercise.reps}回`}
+                          </span>
+                        </li>
+                      ))}
                     </ul>
                   </li>
                 ))}

--- a/frontend/src/components/TrainingMenu/styles/TrainingMenu.css
+++ b/frontend/src/components/TrainingMenu/styles/TrainingMenu.css
@@ -115,6 +115,41 @@
   text-align: left;
 }
 
+
+.training-menu-list li ul {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+
+.training-menu-exercise-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  padding: 5px 0;
+}
+
+
+.training-menu-exercise-icon {
+  cursor: pointer;
+  font-size: 18px;
+  margin-right: 10px;
+  color: #007bff;
+  transition: color 0.3s ease;
+  flex-shrink: 0;
+}
+
+.training-menu-exercise-icon:hover {
+  color: #0056b3;
+  transform: scale(1.1);
+}
+
+.training-menu-exercise-details {
+  flex: 1;
+  font-size: 16px;
+}
+
 /* メニュー曜日 */
 .training-menu-day {
   font-weight: bold;
@@ -184,6 +219,11 @@
 
 .training-menu-save-button:hover {
   background-color: #0056b3;
+}
+
+.training-menu-save-button-disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
 }
 
 .training-menu-calendar-modal-overlay,
@@ -305,6 +345,16 @@
   .training-menu-list li ul li {
     font-size: 14px;
   }
+
+
+  .training-menu-exercise-icon {
+    font-size: 16px;
+    margin-right: 8px;
+  }
+
+  .training-menu-exercise-details {
+    font-size: 14px;
+  }
 }
 
 @media screen and (max-width: 480px) {
@@ -336,5 +386,16 @@
   .training-menu-list li ul li {
     font-size: 11px;
     line-height: 1.4;
+  }
+
+
+  .training-menu-exercise-icon {
+    font-size: 14px;
+    margin-right: 6px;
+  }
+
+
+  .training-menu-exercise-details {
+    font-size: 11px;
   }
 }


### PR DESCRIPTION
提案されたトレーニングメニューの種目が分からない。とお問合せを頂いていたので、
画像のように？のアイコンを設置して、クリックすると種目の説明サイトに飛ぶ機能を追加。
<img width="1440" alt="スクリーンショット 2025-06-01 5 27 09" src="https://github.com/user-attachments/assets/83003926-a5fb-4829-9498-2a2014b3b95b" />

※まだ一部しかサイトの登録をしていないので、
　別途、種目ごとにサイトを登録する必要あり。

編集ファイル
frontend/src/components/TrainingMenu/styles/TrainingMenu.css
frontend/src/components/TrainingMenu/GetTrainingMenuMen1.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuMen2.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuMen3.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuMen4.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuMen5.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuMen6.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman1.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman2.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman3.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman4.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman5.jsx
frontend/src/components/TrainingMenu/GetTrainingMenuWoman6.jsx
frontend/src/components/TrainingMenu/TrainingMenu.jsx