### PR TITLE
カレンダーの一年前後に移動する「<<」のボタンを削除

### DIFF
--- a/frontend/src/components/Home/Body/Calender/styles/Calendar.css
+++ b/frontend/src/components/Home/Body/Calender/styles/Calendar.css
@@ -47,6 +47,12 @@
     background-color: rgba(255, 255, 255, 0.2);
 }
 
+
+.react-calendar__navigation__prev2-button,
+.react-calendar__navigation__next2-button {
+    display: none;
+}
+
 /* ナビゲーションラベルのスタイル */
 .react-calendar__navigation__label {
     display: block;


### PR DESCRIPTION

<img width="673" alt="スクリーンショット 2025-06-02 20 54 23" src="https://github.com/user-attachments/assets/c79aaa64-86b2-4531-9e11-d50c4615dba0" />

カレンダーの一年前後に移動する「<<」のボタンを削除

frontend/src/components/Home/Body/Calender/styles/Calendar.css
下記のコードを追加しただけ

```
.react-calendar__navigation__prev2-button,
.react-calendar__navigation__next2-button {
    display: none;
}
```