### PR TITLE
239 トレーニング画面一部修正

### DIFF
--- a/frontend/src/components/Home/Body/Calender/styles/Calendar.css
+++ b/frontend/src/components/Home/Body/Calender/styles/Calendar.css
@@ -291,3 +291,10 @@
     background: linear-gradient(135deg, rgba(173, 216, 230, 0.7) 50%, rgba(208, 231, 255, 0.7) 50%);
     border: 2px solid #b0d4ff;
 }
+
+
+@media (max-width: 480px) {
+    .react-calendar {
+        margin-top: 60px;
+    }
+}

--- a/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/TrainingRecord.jsx
+++ b/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/TrainingRecord.jsx
@@ -584,7 +584,7 @@ const TrainingRecord = () => {
     </div>
   ))
 ) : (
-  <p className="no-training-data">トレーニングデータがありません。</p>
+  null
 )}
       <TrainingAdder addTraining={addTraining} />
       {message && <p className={messageClass}>{message}</p>}

--- a/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/styles/training-adder.css
+++ b/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/styles/training-adder.css
@@ -20,7 +20,7 @@
     margin-left: auto;
     margin-right: auto;
     margin-top: 0px;
-    margin-bottom:100px;
+    margin-bottom:80px;
     font-weight: bold;
     cursor: pointer;
 }

--- a/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/styles/training-record-container.css
+++ b/frontend/src/components/Home/Body/TrainingRecord/TrainingTable/styles/training-record-container.css
@@ -40,20 +40,6 @@
   transform: translateY(-2px);
 }
 
-.no-training-data {
-  color: #ff6347;
-  font-size: 18px;
-  text-align: center;
-  margin-top: 30px;
-  font-weight: bold;
-  background-color: rgba(255, 99, 71, 0.1);
-  padding: 10px;
-  border-radius: 5px;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  width: fit-content;
-}
 
 /* ログイン警告メッセージのスタイル */
 .login-warning-message {


### PR DESCRIPTION
改善前
<img width="1680" alt="スクリーンショット 2025-06-03 0 22 47" src="https://github.com/user-attachments/assets/2f60d17b-034e-4294-84ac-d59012e39a74" />
<img width="388" alt="スクリーンショット 2025-06-03 0 23 50" src="https://github.com/user-attachments/assets/9e6fa057-40a3-4b8d-b8ff-063238133545" />


改善後
<img width="1680" alt="スクリーンショット 2025-06-03 0 23 04" src="https://github.com/user-attachments/assets/921552fa-1291-434e-9952-495bbff6117c" />
<img width="392" alt="スクリーンショット 2025-06-03 0 23 29" src="https://github.com/user-attachments/assets/6ae4606a-c39d-4345-9f58-5f0058c2b1e7" />



トレーニング画面の「トレーニングデータがありません」の表示機能を削除
※シンプルさの追求のため

frontend/src/components/Home/Body/TrainingRecord/TrainingTable/TrainingRecord.jsx
frontend/src/components/Home/Body/TrainingRecord/TrainingTable/styles/training-record-container.css